### PR TITLE
the script start_server.sh needs to be executable to allow the Rails server to startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,5 +6,6 @@ rm -rf /usr/share/configure_wifi
 mkdir /usr/share/configure_wifi
 chmod 775 /usr/share/configure_wifi
 cp -r * /usr/share/configure_wifi
+chmod 775 /usr/share/configure_wifi/start_server.sh
 echo "Starting Main installer script..."
 python3 /usr/share/configure_wifi/initial_setup.py


### PR DESCRIPTION
I installed a clean Raspbian Stretch on a RPi Zero W and followed the installation instruction given here. However, the Web server was not started after reboot. Making the script start_server.sh executable resolved this.